### PR TITLE
Ensure dark mode text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,19 +180,19 @@
     </section>
 
     <!-- Preuves -->
-    <section class="py-16 bg-gray-50">
+    <section class="py-16 bg-gray-50 dark:bg-gray-900">
       <div class="container mx-auto px-4">
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-8 text-center">
-          <div class="fade-in"><div class="bg-white p-6 rounded-lg shadow-lg">
+          <div class="fade-in"><div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg">
             <svg class="w-12 h-12 text-primary mx-auto mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
             <h3 class="font-semibold">Assurance Décennale</h3></div></div>
-          <div class="fade-in"><div class="bg-white p-6 rounded-lg shadow-lg">
+          <div class="fade-in"><div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg">
             <svg class="w-12 h-12 text-primary mx-auto mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L10 9.586V6z" clip-rule="evenodd"/></svg>
             <h3 class="font-semibold">Intervention sous 48h</h3></div></div>
-          <div class="fade-in"><div class="bg-white p-6 rounded-lg shadow-lg">
+          <div class="fade-in"><div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg">
             <svg class="w-12 h-12 text-primary mx-auto mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             <h3 class="font-semibold">Devis Gratuit</h3></div></div>
-          <div class="fade-in"><div class="bg-white p-6 rounded-lg shadow-lg">
+          <div class="fade-in"><div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg">
             <svg class="w-12 h-12 text-primary mx-auto mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z"/></svg>
             <h3 class="font-semibold">Équipe Qualifiée</h3></div></div>
         </div>
@@ -203,7 +203,7 @@
     <section id="apropos" class="py-20">
       <div class="container mx-auto px-4">
         <div class="max-w-4xl mx-auto text-center">
-          <h2 class="text-4xl font-bold mb-8 text-secondary fade-in">À propos de SARL BRUNO MIRA</h2>
+          <h2 class="text-4xl font-bold mb-8 text-secondary dark:text-gray-100 fade-in">À propos de SARL BRUNO MIRA</h2>
           <p class="text-lg text-gray-700 mb-8 fade-in">Forte de plus de 15 ans d'expérience dans le BTP, SARL BRUNO MIRA est votre partenaire de confiance pour tous vos projets de construction et de rénovation dans l'Hérault. Notre équipe de professionnels qualifiés vous garantit des travaux de qualité, dans le respect des délais et des normes de sécurité.</p>
           <div class="grid md:grid-cols-3 gap-8 mt-12">
             <div class="text-center fade-in"><div class="bg-primary text-white rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4"><span class="text-2xl font-bold">15+</span></div><h3 class="font-semibold mb-2">Années d'expérience</h3><p class="text-gray-600">Un savoir-faire éprouvé</p></div>
@@ -215,20 +215,20 @@
     </section>
 
     <!-- Services -->
-    <section id="services" class="py-20 bg-gray-50">
+    <section id="services" class="py-20 bg-gray-50 dark:bg-gray-900">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Nos Services BTP</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Nos Services BTP</h2>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           <!-- Repeatable service card -->
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><h3 class="text-xl font-semibold mb-3">Gros Œuvre</h3><p class="text-gray-600">Fondations, murs porteurs, dalles, charpente. Construction neuve et extension.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm0 4a1 1 0 011-1h12a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1V8z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Maçonnerie</h3><p class="text-gray-600">Murs en parpaings, briques, pierres. Cloisons et ouvertures.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z"/></svg><h3 class="text-xl font-semibold mb-3">Électricité</h3><p class="text-gray-600">Installation, mise aux normes, dépannage.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Plomberie</h3><p class="text-gray-600">Sanitaire, chauffage, dépannage 24/7.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Plaquisterie</h3><p class="text-gray-600">Cloisons sèches, faux plafonds, isolation.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M3 4a1 1 0 000 2h14a1 1 0 100-2H3zM3 8a1 1 0 000 2h14a1 1 0 100-2H3zM3 12a1 1 0 100 2h14a1 1 0 100-2H3z"/></svg><h3 class="text-xl font-semibold mb-3">Carrelage</h3><p class="text-gray-600">Sol et mur, faïence, pierres naturelles.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M4 3a2 2 0 100 4h12a2 2 0 100-4H4zM4 9a2 2 0 100 4h12a2 2 0 100-4H4zM4 15a2 2 0 100 4h12a2 2 0 100-4H4z"/></svg><h3 class="text-xl font-semibold mb-3">Peinture</h3><p class="text-gray-600">Intérieur/extérieur, enduits décoratifs, ravalement.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Menuiserie</h3><p class="text-gray-600">Ouvertures, volets, escaliers, sur-mesure.</p></div>
-          <div class="bg-white p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A.997.997 0 012 10V5a3 3 0 013-3h5c.256 0 .512.098.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Rénovation Complète</h3><p class="text-gray-600">Cuisines & Salles de bains clé en main.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/></svg><h3 class="text-xl font-semibold mb-3">Gros Œuvre</h3><p class="text-gray-600">Fondations, murs porteurs, dalles, charpente. Construction neuve et extension.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="2" y="4" width="8" height="4"/><rect x="14" y="4" width="8" height="4"/><rect x="2" y="10" width="8" height="4"/><rect x="14" y="10" width="8" height="4"/><rect x="8" y="16" width="8" height="4"/></svg><h3 class="text-xl font-semibold mb-3">Maçonnerie</h3><p class="text-gray-600">Murs en parpaings, briques, pierres. Cloisons et ouvertures.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path fill-rule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clip-rule="evenodd"/></svg><h3 class="text-xl font-semibold mb-3">Électricité</h3><p class="text-gray-600">Installation, mise aux normes, dépannage.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C9 6 5 9.5 5 14a7 7 0 0014 0c0-4.5-4-8-7-12z"/></svg><h3 class="text-xl font-semibold mb-3">Plomberie</h3><p class="text-gray-600">Sanitaire, chauffage, dépannage 24/7.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><circle cx="8" cy="8" r="1"/><circle cx="16" cy="8" r="1"/><circle cx="8" cy="16" r="1"/><circle cx="16" cy="16" r="1"/></svg><h3 class="text-xl font-semibold mb-3">Plaquisterie</h3><p class="text-gray-600">Cloisons sèches, faux plafonds, isolation.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></svg><h3 class="text-xl font-semibold mb-3">Carrelage</h3><p class="text-gray-600">Sol et mur, faïence, pierres naturelles.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="4" y="3" width="12" height="6" rx="1"/><path d="M10 9v5a2 2 0 002 2h4v3h-6a4 4 0 01-4-4V9h4z"/></svg><h3 class="text-xl font-semibold mb-3">Peinture</h3><p class="text-gray-600">Intérieur/extérieur, enduits décoratifs, ravalement.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M2 10l6-6 3 3-1.5 1.5 4 4L12 14l-4-4-1.5 1.5L3 9z"/><rect x="11" y="11" width="2" height="10" transform="rotate(-45 12 12)"/></svg><h3 class="text-xl font-semibold mb-3">Menuiserie</h3><p class="text-gray-600">Ouvertures, volets, escaliers, sur-mesure.</p></div>
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg hover:shadow-xl transition-shadow fade-in"><svg class="w-12 h-12 text-primary mb-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4 4v6h6L7.5 8.5A7 7 0 1112 19v2a9 9 0 100-18H4z"/></svg><h3 class="text-xl font-semibold mb-3">Rénovation Complète</h3><p class="text-gray-600">Cuisines & Salles de bains clé en main.</p></div>
         </div>
       </div>
     </section>
@@ -236,7 +236,7 @@
     <!-- Process -->
     <section id="process" class="py-20">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Notre Process en 4 Étapes</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Notre Process en 4 Étapes</h2>
         <div class="max-w-4xl mx-auto grid md:grid-cols-2 lg:grid-cols-4 gap-8">
           <div class="text-center fade-in"><div class="bg-primary text-white rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4"><span class="text-2xl font-bold">1</span></div><h3 class="text-xl font-semibold mb-3">Visite & Étude</h3><p class="text-gray-600">Déplacement gratuit pour comprendre vos besoins.</p></div>
           <div class="text-center fade-in"><div class="bg-primary text-white rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4"><span class="text-2xl font-bold">2</span></div><h3 class="text-xl font-semibold mb-3">Devis Détaillé</h3><p class="text-gray-600">Proposition sous 48h avec planning transparent.</p></div>
@@ -247,9 +247,9 @@
     </section>
 
     <!-- Réalisations -->
-    <section id="realisations" class="py-20 bg-gray-50">
+    <section id="realisations" class="py-20 bg-gray-50 dark:bg-gray-900">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Nos Réalisations</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Nos Réalisations</h2>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
           <div class="fade-in cursor-pointer" onclick="openLightbox('https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=1200&q=80')"><img src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=800&q=80" alt="Rénovation maison Hérault" class="rounded-lg shadow-lg hover:shadow-xl transition-shadow w-full h-64 object-cover" loading="lazy" /><h3 class="text-lg font-semibold mt-4">Rénovation Complète - Montpellier</h3></div>
           <div class="fade-in cursor-pointer" onclick="openLightbox('https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?auto=format&fit=crop&w=1200&q=80')"><img src="https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?auto=format&fit=crop&w=800&q=80" alt="Extension maison Béziers" class="rounded-lg shadow-lg hover:shadow-xl transition-shadow w-full h-64 object-cover" loading="lazy" /><h3 class="text-lg font-semibold mt-4">Extension - Béziers</h3></div>
@@ -264,20 +264,20 @@
     <!-- Avis -->
     <section id="avis" class="py-20">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Avis de nos Clients</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Avis de nos Clients</h2>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
           <!-- 3 testimonials -->
-          <div class="bg-white p-6 rounded-lg shadow-lg fade-in">
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg fade-in">
             <div class="flex mb-4" aria-hidden="true">⭐⭐⭐⭐⭐</div>
             <p class="text-gray-700 mb-4">"Excellent travail pour la rénovation de notre maison. Équipe professionnelle, délais respectés et finitions parfaites. Je recommande vivement !"</p>
             <p class="font-semibold">Marie Dubois - Montpellier</p>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow-lg fade-in">
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg fade-in">
             <div class="flex mb-4" aria-hidden="true">⭐⭐⭐⭐⭐</div>
             <p class="text-gray-700 mb-4">"Bruno et son équipe ont refait notre cuisine entièrement. Travail soigné, prix honnête et très bon contact. Merci !"</p>
             <p class="font-semibold">Pierre Martin - Béziers</p>
           </div>
-          <div class="bg-white p-6 rounded-lg shadow-lg fade-in">
+          <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg fade-in">
             <div class="flex mb-4" aria-hidden="true">⭐⭐⭐⭐⭐</div>
             <p class="text-gray-700 mb-4">"Intervention rapide pour un dépannage plomberie. Professionnel et efficace, je garde le contact pour mes futurs travaux."</p>
             <p class="font-semibold">Sophie Laurent - Agde</p>
@@ -285,15 +285,15 @@
         </div>
         <div class="text-center mt-12 fade-in">
           <a href="https://g.page/r/CbP6b2XKrSy2EBE" target="_blank" rel="noopener" class="bg-primary hover:bg-red-700 text-white px-8 py-3 rounded-lg font-semibold transition-colors">Voir notre fiche Google</a>
-          <a href="https://g.page/r/CbP6b2XKrSy2EBE/review" target="_blank" rel="noopener" class="inline-block ml-3 text-secondary underline hover:text-primary">Publier un avis</a>
+          <a href="https://g.page/r/CbP6b2XKrSy2EBE/review" target="_blank" rel="noopener" class="inline-block ml-3 text-secondary dark:text-gray-100 underline hover:text-primary">Publier un avis</a>
         </div>
       </div>
     </section>
 
     <!-- Zone d'intervention -->
-    <section id="zone" class="py-20 bg-gray-50">
+    <section id="zone" class="py-20 bg-gray-50 dark:bg-gray-900">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Zone d'Intervention</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Zone d'Intervention</h2>
         <div class="max-w-4xl mx-auto grid md:grid-cols-2 gap-8 items-start">
           <div class="fade-in">
             <iframe title="Carte de l'Hérault" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d92661.11853635626!2d3.7835836!3d43.6047!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12b6af0725dd9db1%3A0xa1d6e4f5d4e8b8b!2sH%C3%A9rault%2C%20France!5e0!3m2!1sfr!2sfr!4v1700000000000" width="100%" height="300" style="border:0; border-radius: 8px;" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
@@ -324,53 +324,53 @@
     <!-- FAQ -->
     <section id="faq" class="py-20">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Questions Fréquentes</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Questions Fréquentes</h2>
         <div class="max-w-4xl mx-auto space-y-6">
           <!-- FAQ item template -->
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Proposez-vous des devis gratuits ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Oui, devis gratuits et sans engagement. Un professionnel se déplace et vous remet une proposition détaillée sous 48h.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Quels sont vos délais d'intervention ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Urgences sous 48h. Pour les chantiers, le planning est défini au devis selon l'ampleur des travaux.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Êtes-vous assurés et certifiés ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Oui, responsabilité civile et décennale. Attestations disponibles sur demande.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Particuliers et professionnels ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Oui, nous intervenons pour particuliers, entreprises, syndics et collectivités.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Facilités de paiement ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Paiements échelonnés possibles selon l'avancement. Étude au cas par cas pour les gros projets.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Quelles garanties appliquez-vous ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
             <div class="faq-content hidden px-6 pb-4"><p class="text-gray-700">Parfait achèvement (1 an), bon fonctionnement (2 ans), décennale (10 ans) selon les travaux.</p></div>
           </div>
-          <div class="bg-white rounded-lg shadow-lg fade-in">
-            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 flex justify-between items-center">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg fade-in">
+            <button class="faq-button w-full px-6 py-4 text-left font-semibold text-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex justify-between items-center">
               <span>Fournissez-vous les matériaux ?</span>
               <svg class="w-5 h-5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </button>
@@ -381,13 +381,13 @@
     </section>
 
     <!-- Contact -->
-    <section id="contact" class="py-20 bg-gray-50">
+    <section id="contact" class="py-20 bg-gray-50 dark:bg-gray-900">
       <div class="container mx-auto px-4">
-        <h2 class="text-4xl font-bold text-center mb-16 text-secondary fade-in">Contactez-nous</h2>
+        <h2 class="text-4xl font-bold text-center mb-16 text-secondary dark:text-gray-100 fade-in">Contactez-nous</h2>
         <div class="max-w-6xl mx-auto grid lg:grid-cols-2 gap-12">
           <!-- Form -->
           <div class="fade-in">
-            <div class="bg-white p-8 rounded-lg shadow-lg">
+            <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
               <h3 class="text-2xl font-semibold mb-6">Demander un devis gratuit</h3>
               <form id="contact-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
                 <!-- Honeypot -->
@@ -441,7 +441,7 @@
           </div>
           <!-- Coordonnées -->
           <div class="fade-in">
-            <div class="bg-white p-8 rounded-lg shadow-lg h-fit">
+            <div class="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg h-fit">
               <h3 class="text-2xl font-semibold mb-6">Nos coordonnées</h3>
               <div class="space-y-6">
                 <div class="flex items-start"><svg class="w-6 h-6 text-primary mt-1 mr-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"/></svg><div><h4 class="font-semibold">Téléphone</h4><a href="tel:0603830649" class="text-primary hover:underline text-lg">06.03.83.06.49</a><p class="text-gray-600 text-sm">Disponible 7j/7 pour urgences</p></div></div>


### PR DESCRIPTION
## Summary
- add dark theme backgrounds to sections and cards for improved readability
- replace service icons with visuals matching each trade

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e45d806fc832abdc896dd82f31498