### PR TITLE
feat: add counter analytics and conversion page

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,8 +668,9 @@ Nous nous engageons à vous offrir des réalisations de qualité, dans le respec
           });
 
           if (resp.ok) {
-            statusEl.textContent = 'Merci ! Votre demande a bien été envoyée.';
-            form.reset();
+            const base = location.pathname.includes('/site-bruno-miraa/') ? '/site-bruno-miraa/' : '/';
+            window.location.href = location.origin + base + 'merci.html';
+            return;
           } else {
             const data = await resp.json().catch(() => ({}));
             statusEl.textContent = data.errors
@@ -682,6 +683,12 @@ Nous nous engageons à vous offrir des réalisations de qualité, dans le respec
       });
     }
   </script>
+
+  <!-- Counter.dev (analytics sans cookies) -->
+  <script src="https://cdn.counter.dev/script.js"
+          data-id="156b8a98-8c71-4b3e-a8d5-de3547a2e7db"
+          data-utcoffset="1"></script>
+  <!-- /Counter.dev -->
 </body>
 </html>
 

--- a/merci.html
+++ b/merci.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Merci – Demande de devis envoyée</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <h1>Merci ! Votre demande de devis a bien été envoyée ✅</h1>
+  <p>Nous vous recontactons très vite.</p>
+
+  <!-- Counter.dev (analytics sans cookies) -->
+  <script src="https://cdn.counter.dev/script.js"
+          data-id="156b8a98-8c71-4b3e-a8d5-de3547a2e7db"
+          data-utcoffset="1"></script>
+  <!-- /Counter.dev -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Counter.dev tracking to homepage
- create thank-you page with analytics
- redirect Formspree submissions to conversion page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08b93bef8832abc782ef3e28fa144