### PR TITLE
Fix dark mode form field readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,22 @@
     :focus-visible { outline: 3px solid #dc2626; outline-offset: 2px; }
     .dark .text-gray-700 { color: #d1d5db; }
     .dark .text-gray-600 { color: #9ca3af; }
+    /* Dark mode form inputs */
+    .dark input,
+    .dark select,
+    .dark textarea {
+      background-color: #374151;
+      color: #f3f4f6;
+      border-color: #4b5563;
+    }
+    .dark input::placeholder,
+    .dark textarea::placeholder {
+      color: #9ca3af;
+    }
+    .dark select option {
+      background-color: #374151;
+      color: #f3f4f6;
+    }
     button,
     a[class*="bg-primary"] {
       transition: transform .2s ease, box-shadow .2s ease;


### PR DESCRIPTION
## Summary
- ensure form inputs and selects have high-contrast styles in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a08e6b001c832aa0ebc7a259f93d05